### PR TITLE
fixes: upload errors from find video duration

### DIFF
--- a/mentor_upload_worker/src/mentor_upload_process/media_tools.py
+++ b/mentor_upload_worker/src/mentor_upload_process/media_tools.py
@@ -12,6 +12,17 @@ import ffmpy
 from pymediainfo import MediaInfo
 
 
+def find_duration(audio_or_video_file: str) -> float:
+    media_info = MediaInfo.parse(audio_or_video_file)
+    for t in media_info.tracks:
+        if t.track_type in ["Video", "Audio"]:
+            try:
+                return float(t.duration)
+            except Exception:
+                pass
+    return -1.0
+
+
 def find_video_dims(video_file: str) -> Tuple[int, int]:
     media_info = MediaInfo.parse(video_file)
     video_tracks = [t for t in media_info.tracks if t.track_type == "Video"]
@@ -20,14 +31,6 @@ def find_video_dims(video_file: str) -> Tuple[int, int]:
         if len(video_tracks) >= 1
         else (-1, -1)
     )
-
-
-def find_video_duration(video_file: str) -> float:
-    media_info = MediaInfo.parse(video_file)
-    for t in media_info.tracks:
-        if t.track_type in ["Video", "Audio"]:
-            return t.duration
-    return 0
 
 
 def format_secs(secs: Union[float, int, str]) -> str:
@@ -203,14 +206,16 @@ def find(
     return [i for i, ltr in enumerate(s) if ltr == ch]
 
 
-def transcript_to_vtt(video_file: str, vtt_file: str, transcript: str) -> str:
-    if not os.path.exists(video_file):
-        raise Exception(f"ERROR: Can't generate vtt, {video_file} doesn't exist")
-    duration = find_video_duration(video_file)
-    if duration == 0:
+def transcript_to_vtt(audio_or_video_file: str, vtt_file: str, transcript: str) -> str:
+    if not os.path.exists(audio_or_video_file):
+        raise Exception(
+            f"ERROR: Can't generate vtt, {audio_or_video_file} doesn't exist"
+        )
+    duration = find_duration(audio_or_video_file)
+    if duration <= 0:
         import logging
 
-        logging.warning(f"video duration for {video_file} returned 0")
+        logging.warning(f"video duration for {audio_or_video_file} returned 0")
         return ""
     piece_length = 68
     word_indexes = find(transcript, " ")

--- a/mentor_upload_worker/src/mentor_upload_process/process.py
+++ b/mentor_upload_worker/src/mentor_upload_process/process.py
@@ -157,7 +157,13 @@ def process_answer_video(
             job_result = transcribe_result.first()
             transcript = job_result.transcript if job_result else ""
             vtt_file = work_dir / "subtitles.vtt"
-            transcript_to_vtt(video_file, vtt_file, transcript)
+            try:
+                transcript_to_vtt(video_file, vtt_file, transcript)
+            except Exception as vtt_err:
+                import logging
+
+                logging.error(f"Failed to create vtt file")
+                logging.exception(vtt_err)
             update_status(
                 StatusUpdateRequest(
                     mentor=mentor,

--- a/mentor_upload_worker/tests/test_process_answer_video.py
+++ b/mentor_upload_worker/tests/test_process_answer_video.py
@@ -244,7 +244,7 @@ class _TestProcessExample:
 
 
 @responses.activate
-@patch("mentor_upload_process.media_tools.video_duration")
+@patch("mentor_upload_process.media_tools.find_video_duration")
 @patch.object(transcribe, "init_transcription_service")
 @patch("ffmpy.FFmpeg")
 @patch("boto3.client")

--- a/mentor_upload_worker/tests/test_process_answer_video.py
+++ b/mentor_upload_worker/tests/test_process_answer_video.py
@@ -244,7 +244,7 @@ class _TestProcessExample:
 
 
 @responses.activate
-@patch("mentor_upload_process.media_tools.find_video_duration")
+@patch("mentor_upload_process.media_tools.find_duration")
 @patch.object(transcribe, "init_transcription_service")
 @patch("ffmpy.FFmpeg")
 @patch("boto3.client")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black==20.8b1
-flake8==3.9.1
+flake8==3.9.2
 mypy==v0.782
-pep8-naming==0.11.1
+pep8-naming==0.12.0
 pip-upgrader
 licenseheaders @ git+http://github.com/kycarr/licenseheaders.git@master#egg=licenseheaders


### PR DESCRIPTION
The code we're using to get video duration for vtt is throwing exceptions and causing the whole upload process to fail, (error sample below).

For fix doing two things:

- switch back to pymediainfo for finding duration
- catch exceptions from vtt generation and log but don't fail

```log
Traceback (most recent call last):
  File "/app/mentor_upload_process/process.py", line 160, in process_answer_video
    transcript_to_vtt(video_file, vtt_file, transcript)
  File "/app/mentor_upload_process/media_tools.py", line 220, in transcript_to_vtt
    duration = video_duration(video_file)
  File "/app/mentor_upload_process/media_tools.py", line 208, in video_duration
    return float(ffprobe[0].decode("utf-8"))
ValueError: could not convert string to float: 'N/A\n'
```