### PR TITLE
impr: uses celery queues to allow for sharing an exchange (transition from redis to SQS)

### DIFF
--- a/mentor_upload_api/src/mentor_upload_api/blueprints/upload/answer.py
+++ b/mentor_upload_api/src/mentor_upload_api/blueprints/upload/answer.py
@@ -9,6 +9,7 @@ from os import environ, path, makedirs
 import uuid
 
 from flask import Blueprint, jsonify, request
+
 from mentor_upload_api.api import (
     StatusUpdateRequest,
     update_status,
@@ -48,7 +49,9 @@ def upload():
         "video_path": file_name,
         "trim": trim,
     }
-    t = mentor_upload_tasks.tasks.process_answer_video.apply_async(args=[req])
+    t = mentor_upload_tasks.tasks.process_answer_video.apply_async(
+        queue=mentor_upload_tasks.get_queue_uploads(), args=[req]
+    )
     update_status(
         StatusUpdateRequest(
             mentor=mentor,
@@ -79,7 +82,9 @@ def cancel():
     question = body.get("question")
     task_id = body.get("task")
     req = {"mentor": mentor, "question": question, "task_id": task_id}
-    t = mentor_upload_tasks.tasks.cancel_task.apply_async(args=[req])
+    t = mentor_upload_tasks.tasks.cancel_task.apply_async(
+        queue=mentor_upload_tasks.get_queue_uploads(), args=[req]
+    )
     return jsonify({"data": {"id": t.id, "cancelledId": task_id}})
 
 

--- a/mentor_upload_api/src/mentor_upload_api/blueprints/upload/transfer.py
+++ b/mentor_upload_api/src/mentor_upload_api/blueprints/upload/transfer.py
@@ -34,7 +34,9 @@ def transfer():
         "mentor": mentor,
         "question": question,
     }
-    t = mentor_upload_tasks.tasks.process_transfer_video.apply_async(args=[req])
+    t = mentor_upload_tasks.tasks.process_transfer_video.apply_async(
+        queue=mentor_upload_tasks.get_queue_uploads(), args=[req]
+    )
     return jsonify(
         {
             "data": {
@@ -55,7 +57,9 @@ def cancel():
     question = body.get("question")
     task_id = body.get("task")
     req = {"mentor": mentor, "question": question, "task_id": task_id}
-    t = mentor_upload_tasks.tasks.cancel_task.apply_async(args=[req])
+    t = mentor_upload_tasks.tasks.cancel_task.apply_async(
+        queue=mentor_upload_tasks.get_queue_uploads(), args=[req]
+    )
     return jsonify({"data": {"id": t.id, "cancelledId": task_id}})
 
 

--- a/mentor_upload_api/src/mentor_upload_tasks/__init__.py
+++ b/mentor_upload_api/src/mentor_upload_tasks/__init__.py
@@ -4,7 +4,12 @@
 #
 # The full terms of this copyright and license should always be found in the root directory of this software deliverable as "license.txt" and if these terms are not found with this software, please contact the USC Stevens Center for the full license.
 #
+from os import environ
 from typing import TypedDict
+
+
+def get_queue_uploads() -> str:
+    return environ.get("UPLOAD_QUEUE_NAME") or "uploads"
 
 
 class TrimRequest(TypedDict):

--- a/mentor_upload_api/src/mentor_upload_tasks/tasks.py
+++ b/mentor_upload_api/src/mentor_upload_tasks/tasks.py
@@ -7,19 +7,44 @@
 import os
 
 from celery import Celery
+from kombu import Exchange, Queue
 
-from . import CancelTaskRequest, ProcessAnswerRequest, ProcessTransferRequest
+from . import (
+    CancelTaskRequest,
+    ProcessAnswerRequest,
+    ProcessTransferRequest,
+    get_queue_uploads,
+)
 
-config = {
-    "broker_url": os.environ.get("CELERY_BROKER_URL", "redis://redis:6379/0"),
-    "result_backend": os.environ.get("CELERY_RESULT_BACKEND", "redis://redis:6379/0"),
-    "accept_content": ["json"],
-    "task_serializer": os.environ.get("CELERY_TASK_SERIALIZER", "json"),
-    "event_serializer": os.environ.get("CELERY_EVENT_SERIALIZER", "json"),
-    "result_serializer": os.environ.get("CELERY_RESULT_SERIALIZER", "json"),
-}
-celery = Celery("mentor_upload_tasks", broker=config["broker_url"])
-celery.conf.update(config)
+broker_url = (
+    os.environ.get("UPLOAD_CELERY_BROKER_URL")
+    or os.environ.get("CELERY_BROKER_URL")
+    or "redis://redis:6379/0"
+)
+celery = Celery("mentor_upload_tasks", broker=broker_url)
+celery.conf.update(
+    {
+        "accept_content": ["json"],
+        "broker_url": broker_url,
+        "event_serializer": os.environ.get("CELERY_EVENT_SERIALIZER", "json"),
+        "result_backend": os.environ.get(
+            "CELERY_RESULT_BACKEND", "redis://redis:6379/0"
+        ),
+        "result_serializer": os.environ.get("CELERY_RESULT_SERIALIZER", "json"),
+        "task_default_queue": get_queue_uploads(),
+        "task_default_exchange": get_queue_uploads(),
+        "task_default_routing_key": get_queue_uploads(),
+        "task_queues": [
+            Queue(
+                get_queue_uploads(),
+                exchange=Exchange(get_queue_uploads(), "direct", durable=True),
+                routing_key=get_queue_uploads(),
+            )
+        ],
+        "task_routes": {"mentor_upload_tasks.tasks.*": {"queue": get_queue_uploads()}},
+        "task_serializer": os.environ.get("CELERY_TASK_SERIALIZER", "json"),
+    }
+)
 
 
 @celery.task()
@@ -35,4 +60,3 @@ def process_transfer_video(req: ProcessTransferRequest):
 @celery.task()
 def cancel_task(req: CancelTaskRequest):
     celery.control.revoke(req.get("task_id"), terminate=True)
-    pass

--- a/mentor_upload_worker/Dockerfile
+++ b/mentor_upload_worker/Dockerfile
@@ -1,12 +1,37 @@
-FROM python:3.8-slim
+FROM python:3.8-slim as builder
+# To use celery over AWS SQS requires pycurl
+# and it doesn't work unless it's compiled,
+# which requires hundreds of MB of build tools...
+# So we do a two-phase docker build.
+# In the first phase, we compile pycurl
+# as a wheel, and then in the final phase,
+# we install from that wheel (to avoid needing the build tools)
 RUN apt-get update && \
     apt-get install -y \
-    ffmpeg \
-    git \
-    mediainfo \
-    && rm -rf /var/lib/apt/lists/*
+        build-essential \
+        libcurl4-openssl-dev \
+        libssl-dev \
+    && pip install wheel \
+    && pip wheel \
+            --wheel-dir=/svc/wheels \
+            --no-binary :all: \
+            --global-option="--with-openssl" \
+            --no-cache-dir \
+        pycurl
+FROM python:3.8-slim
+COPY --from=builder /svc /svc
+WORKDIR /svc
 ADD requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+RUN apt-get update && \
+    apt-get install -y \
+        ffmpeg \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        mediainfo \
+    && pip install -r /tmp/requirements.txt \
+    && pip uninstall pycurl \
+    && pip install --no-index --find-links=/svc/wheels pycurl \
+    && rm -rf /var/lib/apt/lists/*
 RUN rm /tmp/requirements.txt
 WORKDIR /app
 COPY src ./


### PR DESCRIPTION
This PR enables us to change the way we do asynchronous-task queueing. Up until now, we've been using CELERY over REDIS, but there were two big problems:

 - we needed one REDIS instance per queue (one for UPLOADS and another for CLASSIFIER)
 - the REDIS instances are living inside each single ElasticBeanstalk instance, so the tasks can never be spread among instances

The fix will be to stop using REDIS under CELERY and instead use (global) AWS SQS, enabled by this PR