### PR TITLE
impr: makes easier to override celery result backend w env

### DIFF
--- a/mentor_upload_api/requirements.txt
+++ b/mentor_upload_api/requirements.txt
@@ -4,7 +4,8 @@ celery==5.1.2
 flask==2.0.1
 Flask-Cors==3.0.10
 gunicorn==20.1.0
-python-dotenv==0.18.0
+pymongo==3.2.0
+python-dotenv==0.19.0
 redis==3.5.3
 requests==2.26.0
 werkzeug==2.0.1

--- a/mentor_upload_api/requirements.txt
+++ b/mentor_upload_api/requirements.txt
@@ -4,7 +4,7 @@ celery==5.1.2
 flask==2.0.1
 Flask-Cors==3.0.10
 gunicorn==20.1.0
-pymongo==3.2.0
+pymongo[srv]==3.12.0
 python-dotenv==0.19.0
 redis==3.5.3
 requests==2.26.0

--- a/mentor_upload_api/src/mentor_upload_tasks/tasks.py
+++ b/mentor_upload_api/src/mentor_upload_tasks/tasks.py
@@ -27,8 +27,10 @@ celery.conf.update(
         "accept_content": ["json"],
         "broker_url": broker_url,
         "event_serializer": os.environ.get("CELERY_EVENT_SERIALIZER", "json"),
-        "result_backend": os.environ.get(
-            "CELERY_RESULT_BACKEND", "redis://redis:6379/0"
+        "result_backend": (
+            os.environ.get("UPLOAD_CELERY_RESULT_BACKEND")
+            or os.environ.get("CELERY_RESULT_BACKEND")
+            or "redis://redis:6379/0"
         ),
         "result_serializer": os.environ.get("CELERY_RESULT_SERIALIZER", "json"),
         "task_default_queue": get_queue_uploads(),

--- a/mentor_upload_worker/requirements.txt
+++ b/mentor_upload_worker/requirements.txt
@@ -3,7 +3,8 @@ boto3_type_annotations>=0.3.1
 celery==5.1.2
 ffmpy==0.3.0
 pymediainfo==5.1.0
-python-dotenv==0.18.0
+pymongo==3.2.0
+python-dotenv==0.19.0
 py_transcribe_aws==1.4.2
 redis==3.5.3
 requests==2.26.0

--- a/mentor_upload_worker/requirements.txt
+++ b/mentor_upload_worker/requirements.txt
@@ -3,7 +3,7 @@ boto3_type_annotations>=0.3.1
 celery==5.1.2
 ffmpy==0.3.0
 pymediainfo==5.1.0
-pymongo==3.2.0
+pymongo[srv]==3.12.0
 python-dotenv==0.19.0
 py_transcribe_aws==1.4.2
 redis==3.5.3

--- a/mentor_upload_worker/src/mentor_upload_tasks/tasks.py
+++ b/mentor_upload_worker/src/mentor_upload_tasks/tasks.py
@@ -37,8 +37,10 @@ celery.conf.update(
         "accept_content": ["json"],
         "broker_url": broker_url,
         "event_serializer": os.environ.get("CELERY_EVENT_SERIALIZER", "json"),
-        "result_backend": os.environ.get(
-            "CELERY_RESULT_BACKEND", "redis://redis:6379/0"
+        "result_backend": (
+            os.environ.get("UPLOAD_CELERY_RESULT_BACKEND")
+            or os.environ.get("CELERY_RESULT_BACKEND")
+            or "redis://redis:6379/0"
         ),
         "result_serializer": os.environ.get("CELERY_RESULT_SERIALIZER", "json"),
         "task_default_queue": get_queue_uploads(),


### PR DESCRIPTION
something I missed in last PR about switch to SQS: if we no longer have redis, we need to use mongodb as the celery "result backend"